### PR TITLE
Fix integer overflow on higher voltages.

### DIFF
--- a/src/libs/Arduino-INA219/INA219.cpp
+++ b/src/libs/Arduino-INA219/INA219.cpp
@@ -156,7 +156,7 @@ float INA219::readShuntVoltage(void)
 
 float INA219::readBusVoltage(void)
 {
-    int16_t voltage;
+    uint16_t voltage;
 
     voltage = readRegister16(INA219_REG_BUSVOLTAGE);
     voltage >>= 3;


### PR DESCRIPTION
A simple fix which prevents issues when measuring bus voltages higher than around 16V. In the original code, the integer would overflow on higher voltages and result in negative values. According to INA219 specs, negative voltage in reference to ground should never be attached, and sensor is unable to measure it either, so being able to measure negative voltages isn't beneficial to begin with.